### PR TITLE
Fix: Remove build warnings for successful GitHub Actions deployment

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
@@ -2758,9 +2758,9 @@ footer{margin-top:3rem;text-align:center;font-size:.8em;color:#888}
         }
     }, [atoms, selectedMetal, bestGeometry, fileName, analysisParams, coordRadius, coordAtoms, geometryResults, additionalMetrics, qualityMetrics, warnings]);
 
-    const totalGeometries = useMemo(() => {
-        return Object.values(REFERENCE_GEOMETRIES).reduce((sum, geoms) => sum + Object.keys(geoms).length, 0);
-    }, []);
+//     const totalGeometries = useMemo(() => {
+//         return Object.values(REFERENCE_GEOMETRIES).reduce((sum, geoms) => sum + Object.keys(geoms).length, 0);
+//     }, []);
 
     return (
     <div style={{ 


### PR DESCRIPTION
- Remove unused useMemo import
- Comment out unused totalGeometries variable
- Clean build with zero warnings
- Tested locally: builds successfully (176.53 KB gzipped)

This fixes the GitHub Actions build failure that was preventing deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)