### PR TITLE
Fix: Remove npm cache setting since package-lock.json is not present

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
- Removed cache: 'npm' from setup-node action
- Resolves "Dependencies lock file is not found" error
- npm install will work without caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)