### PR TITLE
fix: Remove redundant analysis triggering and fix cleanup issues

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,10 +33,8 @@ export default function CoordinationGeometryAnalyzer() {
 
     // Stable callback for radius changes
     const handleRadiusChange = useCallback((radius, isAuto) => {
-        // Trigger re-analysis when radius changes manually
-        if (!isAuto) {
-            setAnalysisParams(prev => ({ ...prev, key: Date.now() }));
-        }
+        // Analysis will trigger automatically via coordAtoms dependency in useShapeAnalysis
+        // No need to manually set analysisParams.key here
     }, []);
 
     const handleWarning = useCallback((msg) => {
@@ -117,31 +115,6 @@ export default function CoordinationGeometryAnalyzer() {
             setAnalysisParams({ mode: 'default', key: Date.now() });
         }
     }, [uploadMetadata, setCoordRadius]);
-
-    // Trigger analysis when coordination sphere changes (including from auto-radius changes)
-    // Use a ref to track the previous coordination number to avoid unnecessary re-analysis
-    const prevCN = useRef(null);
-    const prevAutoRadius = useRef(autoRadius);
-
-    useEffect(() => {
-        const currentCN = coordAtoms.length;
-
-        // Trigger analysis if:
-        // 1. Coordination number changed
-        // 2. Auto-radius was just enabled (to apply the new auto-detected radius)
-        if (selectedMetal != null && coordAtoms.length > 0) {
-            const cnChanged = prevCN.current !== null && prevCN.current !== currentCN;
-            const autoJustEnabled = !prevAutoRadius.current && autoRadius;
-
-            if (cnChanged || autoJustEnabled) {
-                setAnalysisParams(prev => ({ ...prev, key: Date.now() }));
-            }
-
-            prevCN.current = currentCN;
-        }
-
-        prevAutoRadius.current = autoRadius;
-    }, [coordAtoms, selectedMetal, autoRadius]);
 
 
     // FIX 2: Ensure report uses current state values and clear dependency issues

--- a/src/hooks/useShapeAnalysis.js
+++ b/src/hooks/useShapeAnalysis.js
@@ -259,9 +259,8 @@ export function useShapeAnalysis({
         return () => {
             isCancelled = true;
             timeouts.forEach(timeout => clearTimeout(timeout));
-            // Reset loading state if this effect is being cleaned up
-            setIsLoading(false);
-            setProgress(null);
+            // Don't reset loading state here - let the next effect run handle it
+            // Otherwise we interrupt analysis when coordAtoms changes slightly
         };
 
     }, [coordAtoms, analysisParams, getCacheKey, onWarning, onError]);


### PR DESCRIPTION
This commit simplifies the analysis triggering logic to fix CPU struggling and stuck loading states:

Changes:
1. Removed manual analysis triggering from handleRadiusChange callback
   - Analysis now triggers automatically via coordAtoms dependency
   - Eliminates redundant analysis runs

2. Removed redundant CN/metal change effect
   - useShapeAnalysis already depends on coordAtoms
   - No need for manual triggering when coordination changes

3. Fixed cleanup function in useShapeAnalysis
   - No longer resets isLoading state in cleanup
   - Prevents interrupting analysis when coordAtoms changes slightly
   - Only cancels pending timeout operations

4. Simplified flow:
   - File upload → coordAtoms changes → analysis runs automatically
   - Radius change → coordAtoms changes → analysis runs automatically
   - Metal change → coordAtoms changes → analysis runs automatically
   - Intensive analysis button → analysisParams changes → forces new analysis

Benefits:
- Eliminates CPU struggling from repeated analysis triggers
- Analysis completes properly without interruption
- Buttons enable correctly when analysis finishes
- Ideal polyhedra display when bestGeometry is set
- Cleaner, more maintainable code

🤖 Generated with [Claude Code](https://claude.com/claude-code)