### PR TITLE
release: Version 1.2.1 - Zenodo DOI Integration

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,50 @@
+{
+  "title": "Q-Shape - Quantitative Shape Analyzer",
+  "version": "v1.2.1",
+  "description": "Q-Shape: Advanced coordination geometry analysis using Continuous Shape Measures (CShM). A web-based tool for analyzing molecular coordination geometries with 80+ reference structures, real-time 3D visualization, and comprehensive quality metrics.",
+  "creators": [
+    {
+      "name": "Castro Silva Junior, Henrique",
+      "orcid": "0000-0003-1453-7274",
+      "affiliation": "Universidade Federal Rural do Rio de Janeiro (UFRRJ), Department of Fundamental Chemistry"
+    }
+  ],
+  "keywords": [
+    "coordination chemistry",
+    "continuous shape measures",
+    "CShM",
+    "molecular geometry",
+    "shape analysis",
+    "coordination geometry",
+    "structural analysis",
+    "computational chemistry",
+    "web application",
+    "Three.js",
+    "React"
+  ],
+  "license": {
+    "id": "MIT"
+  },
+  "upload_type": "software",
+  "access_right": "open",
+  "related_identifiers": [
+    {
+      "scheme": "url",
+      "identifier": "https://github.com/HenriqueCSJ/q-shape",
+      "relation": "isSupplementTo",
+      "resource_type": "software"
+    },
+    {
+      "scheme": "url",
+      "identifier": "https://henriquecsj.github.io/q-shape",
+      "relation": "isDocumentedBy",
+      "resource_type": "other"
+    }
+  ],
+  "references": [
+    "Pinsky, M., & Avnir, D. (1998). Continuous Symmetry Measures. 5. The Classical Polyhedra. Inorganic Chemistry, 37(21), 5575-5582. https://doi.org/10.1021/ic9804925",
+    "Alvarez, S., Avnir, D., Llunell, M., & Pinsky, M. (2002). Continuous symmetry maps and shape classification. The case of six-coordinated metal compounds. New Journal of Chemistry, 26(7), 996-1009. https://doi.org/10.1039/B200641N",
+    "Llunell, M., Casanova, D., Cirera, J., Alemany, P., & Alvarez, S. (2013). SHAPE v2.1. Program for Calculating Continuous Shape Measures of Polyhedral Structures. University of Barcelona, Barcelona, Spain."
+  ],
+  "communities": []
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,37 @@
+cff-version: 1.2.0
+title: "Q-Shape - Quantitative Shape Analyzer"
+message: "If you use Q-Shape in your research, please cite the Zenodo DOI."
+authors:
+  - given-names: Henrique
+    family-names: Castro Silva Junior
+    orcid: "https://orcid.org/0000-0003-1453-7274"
+    email: henriquecsj@ufrrj.br
+    affiliation: "Universidade Federal Rural do Rio de Janeiro (UFRRJ), Department of Fundamental Chemistry"
+repository-code: "https://github.com/HenriqueCSJ/q-shape"
+url: "https://henriquecsj.github.io/q-shape"
+license: MIT
+version: "v1.2.1"
+date-released: "2025-10-26"
+keywords:
+  - "coordination chemistry"
+  - "continuous shape measures"
+  - "CShM"
+  - "molecular geometry"
+  - "shape analysis"
+  - "coordination geometry"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.17448252"
+    description: "Zenodo DOI for version 1.2.1"
+preferred-citation:
+  type: software
+  title: "Q-Shape - Quantitative Shape Analyzer"
+  version: "v1.2.1"
+  year: 2025
+  authors:
+    - given-names: Henrique
+      family-names: Castro Silva Junior
+      orcid: "https://orcid.org/0000-0003-1453-7274"
+  doi: "10.5281/zenodo.17448252"
+  url: "https://doi.org/10.5281/zenodo.17448252"
+  repository-code: "https://github.com/HenriqueCSJ/q-shape"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ![Q-Shape Logo](https://img.shields.io/badge/Q--Shape-Molecular%20Geometry%20Analysis-blue?style=for-the-badge&logo=react&logoColor=white)
 
-[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg?style=flat-square)](https://github.com/HenriqueCSJ/q-shape/releases/tag/v1.2.0)
+[![Version](https://img.shields.io/badge/version-1.2.1-blue.svg?style=flat-square)](https://github.com/HenriqueCSJ/q-shape/releases/tag/v1.2.1)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17448252.svg)](https://doi.org/10.5281/zenodo.17448252)
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](https://choosealicense.com/licenses/mit/)
 [![React Version](https://img.shields.io/badge/React-18.2.0-61DAFB?style=flat-square&logo=react)](https://reactjs.org/)
 [![Three.js](https://img.shields.io/badge/Three.js-r147-black?style=flat-square&logo=three.js)](https://threejs.org/)
@@ -25,18 +26,19 @@
 
 ---
 
-## 🎉 What's New in v1.2.0
+## 🎉 What's New in v1.2.1
 
 <div align="center">
 
 | Feature | Description |
 |---------|-------------|
+| 📚 **Zenodo DOI** | Official DOI for permanent archival and citation: [10.5281/zenodo.17448252](https://doi.org/10.5281/zenodo.17448252) |
 | 🐛 **Critical Fixes** | Fixed infinite loops, auto-radius toggle, and button states that broke v1.1.0 |
 | 🏗️ **Modular Architecture** | Refactored into clean, maintainable modules with comprehensive documentation |
 | 🎯 **Precise Radius Control** | Text input with adjustable step size (±0.50, ±0.10, ±0.05, ±0.01 Å) for fine-tuned radius adjustments |
 | 🔍 **Find Radius by CN** | Automatically finds optimal radius for target coordination number using gap detection algorithm |
 
-[View Release Notes](https://github.com/HenriqueCSJ/q-shape/releases/tag/v1.2.0)
+[View Release Notes](https://github.com/HenriqueCSJ/q-shape/releases/tag/v1.2.1)
 
 </div>
 
@@ -466,14 +468,24 @@ Seropédica, RJ, Brazil
 
 ### Citations
 
-If you use Q-Shape, please cite:
+If you use Q-Shape in your research, please cite:
 
+**APA:**
+```
+Castro Silva Junior, H. (2025). Q-Shape - Quantitative Shape Analyzer (v1.2.1).
+Zenodo. https://doi.org/10.5281/zenodo.17448252
+```
+
+**BibTeX:**
 ```bibtex
 @software{qshape2025,
-  author = {Junior, Henrique C. S.},
-  title = {Q-Shape: Quantitative Shape Analyzer},
+  author = {Castro Silva Junior, Henrique},
+  title = {Q-Shape - Quantitative Shape Analyzer},
+  version = {1.2.1},
   year = {2025},
-  url = {https://github.com/HenriqueCSJ/q-shape}
+  doi = {10.5281/zenodo.17448252},
+  url = {https://doi.org/10.5281/zenodo.17448252},
+  publisher = {Zenodo}
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-shape",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Quantitative Shape Analyzer for Coordination Geometry Analysis",
   "homepage": "https://HenriqueCSJ.github.io/q-shape",
   "private": true,

--- a/src/App.js
+++ b/src/App.js
@@ -720,10 +720,10 @@ footer strong {
             marginTop: '0.5rem',
             fontFamily: 'monospace'
         }}>
-            Version 1.2.0 | Built: October 26, 2025
+            Version 1.2.1 | Built: October 26, 2025
         </p>
-        <p style={{fontStyle: 'italic', marginTop: '1rem'}}>
-            Cite this: Junior, H. C. S. Q-Shape (Quantitative Shape Analyzer). 2025.
+        <p style={{fontStyle: 'italic', marginTop: '1rem', fontSize: '0.9rem'}}>
+            Cite this: Castro Silva Junior, H. (2025). Q-Shape - Quantitative Shape Analyzer (v1.2.1). Zenodo. <a href="https://doi.org/10.5281/zenodo.17448252" target="_blank" rel="noopener noreferrer" style={{color: '#4f46e5'}}>https://doi.org/10.5281/zenodo.17448252</a>
         </p>
       </header>
 


### PR DESCRIPTION
Added official Zenodo DOI for permanent archival and citation.

## Changes

### Version Update
- Bumped version from 1.2.0 to 1.2.1
- Updated all version references in package.json, App.js, and README

### Zenodo Integration
- **DOI Badge**: Added Zenodo DOI badge to README https://doi.org/10.5281/zenodo.17448252

- **CITATION.cff**: Created GitHub citation file for "Cite this repository" feature
  - Includes author ORCID (0000-0003-1453-7274)
  - Proper author name format: Castro Silva Junior, Henrique
  - Structured metadata for automated citation generation

- **.zenodo.json**: Created Zenodo metadata file for future releases
  - Complete author information with ORCID and affiliation
  - Comprehensive keywords for discoverability
  - Related identifiers (GitHub repo, live demo)
  - References to original SHAPE publications
  - Ready for automated Zenodo integration

### Updated Citations
- **App.js**: Updated header citation with full Zenodo reference and clickable DOI link
- **README**:
  - Updated citation section with both APA and BibTeX formats
  - Added Zenodo DOI to What's New section
  - Updated all version badges

### Citation Information

**APA Format:**
Castro Silva Junior, H. (2025). Q-Shape - Quantitative Shape Analyzer (v1.2.1). Zenodo. https://doi.org/10.5281/zenodo.17448252

**BibTeX:**
@software{qshape2025,
  author = {Castro Silva Junior, Henrique},
  title = {Q-Shape - Quantitative Shape Analyzer},
  version = {1.2.1},
  year = {2025},
  doi = {10.5281/zenodo.17448252},
  url = {https://doi.org/10.5281/zenodo.17448252},
  publisher = {Zenodo}
}

🤖 Generated with [Claude Code](https://claude.com/claude-code)