### PR TITLE
fix: Correct reference geometry count from 82 to 87

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 <td width="50%">
 
 ### 🎯 Core Features
-- ✅ **82 Reference Geometries** (CN 2-12)
+- ✅ **87 Reference Geometries** (CN 2-12)
 - ✅ **Improved Kabsch Alignment**
 - ✅ **Optimized Hungarian Algorithm**
 - ✅ **Multi-stage Optimization**
@@ -366,7 +366,7 @@ function kabschAlignment(P, Q) {
 | 11 | 7 | Various capped structures |
 | 12 | 13 | Icosahedron, Cuboctahedron, Hexagonal prism |
 
-**Total: 82 reference geometries**
+**Total: 87 reference geometries**
 
 ---
 


### PR DESCRIPTION
The actual count is 87 reference geometries:
- CN 2: 3
- CN 3: 4
- CN 4: 4
- CN 5: 5
- CN 6: 5
- CN 7: 7
- CN 8: 13
- CN 9: 13
- CN 10: 13
- CN 11: 7
- CN 12: 13 Total: 87

Updated both occurrences in README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)