### PR TITLE
fix: Convert ligandGroups.summary to string to prevent blank page

### DIFF
--- a/src/services/coordination/ringDetector.js
+++ b/src/services/coordination/ringDetector.js
@@ -271,11 +271,10 @@ export function detectLigandGroups(atoms, metalIndex, coordIndices, minRingSize 
         monodentate,
         totalGroups: ligandGroups.length + monodentate.length,
         ringCount: ligandGroups.length,
-        summary: {
-            hasSandwichStructure: ligandGroups.length >= 2 &&
-                                  ligandGroups.every(g => g.size >= 5),
-            detectedHapticities: [...new Set(ligandGroups.map(g => g.hapticity))]
-        }
+        summary: `${ligandGroups.length} ring(s) + ${monodentate.length} monodentate ligand(s)`,
+        hasSandwichStructure: ligandGroups.length >= 2 &&
+                              ligandGroups.every(g => g.size >= 5),
+        detectedHapticities: [...new Set(ligandGroups.map(g => g.hapticity))]
     };
 }
 


### PR DESCRIPTION
The summary was an object { hasSandwichStructure, detectedHapticities } which caused a runtime error when trying to display it as text.

Changed to: "X ring(s) + Y monodentate ligand(s)"
Moved hasSandwichStructure and detectedHapticities to top level.

This fixes the blank page issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)