### PR TITLE
fix: Convert ligandGroups.summary from object to string to prevent Re…

### DIFF
--- a/src/services/coordination/ringDetector.js
+++ b/src/services/coordination/ringDetector.js
@@ -269,11 +269,10 @@ export function detectLigandGroups(atoms, metalIndex, coordIndices, minRingSize 
         monodentate,
         totalGroups: ligandGroups.length + monodentate.length,
         ringCount: ligandGroups.length,
-        summary: {
-            hasSandwichStructure: ligandGroups.length >= 2 &&
-                                  ligandGroups.every(g => g.size >= 5),
-            detectedHapticities: [...new Set(ligandGroups.map(g => g.hapticity))]
-        }
+        summary: `${ligandGroups.length} ring(s) + ${monodentate.length} monodentate ligand(s)`,
+        hasSandwichStructure: ligandGroups.length >= 2 &&
+                              ligandGroups.every(g => g.size >= 5),
+        detectedHapticities: [...new Set(ligandGroups.map(g => g.hapticity))]
     };
 }
 


### PR DESCRIPTION
…act crash

THE ROOT CAUSE: ringDetector.js was returning summary as an OBJECT:
  summary: { hasSandwichStructure: ..., detectedHapticities: [...] }

React error #31: 'Objects are not valid as a React child' When the UI tried to render this object as text, React crashed with blank page.

THE FIX:
- Changed summary to STRING: '2 ring(s) + 0 monodentate ligand(s)'
- Moved hasSandwichStructure and detectedHapticities to separate properties
- Now summary can be safely rendered in UI

This was the SAME bug we fixed before but it came back somehow. The diagnostic logging revealed the exact error and location.

Blank page is now FIXED!