### PR TITLE
fix: Correct two-column grid layout for intensive analysis metadata

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1446,8 +1446,9 @@ footer strong {
            </p>
           </div>
 
-          {/* Intensive Analysis Progress */}
-          {intensiveProgress && (
+          <div>
+            {/* Intensive Analysis Progress */}
+            {intensiveProgress && (
             <div style={{
               marginBottom: '1.5rem',
               padding: '1rem',
@@ -1607,7 +1608,6 @@ footer strong {
             </div>
           )}
 
-          <div>
             <h3 style={{ 
                 margin: '0 0 1rem 0', 
                 color: '#1e293b',


### PR DESCRIPTION
Fixed layout issue where intensive analysis metadata blocks were appearing between the grid columns instead of inside the second column, which was pushing the Geometry Analysis Results section too far down the page.

Changes:
- Wrapped intensive progress and metadata blocks in a containing div
- This div now forms the second column of the main-layout grid
- Intensive metadata now appears above Geometry Analysis Results within the same column, maintaining proper two-column layout

Layout structure now:
- Column 1 (1.5fr): 3D Visualization
- Column 2 (1fr): Intensive Progress + Intensive Metadata + Geometry Results

Fixes layout breaking reported by user.