### PR TITLE
docs: Update Zenodo DOI to v1.4.0 release (10.5281/zenodo.17717110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,7 +256,7 @@ All 116 tests pass ✅
 - Precise radius control with text input
 - Adjustable step size (±0.50, ±0.10, ±0.05, ±0.01 Å)
 - Find Radius by CN feature with gap detection algorithm
-- Official Zenodo DOI: [10.5281/zenodo.17448252](https://doi.org/10.5281/zenodo.17448252)
+- Official Zenodo DOI: [10.5281/zenodo.17717110](https://doi.org/10.5281/zenodo.17717110)
 
 ---
 
@@ -288,6 +288,6 @@ All 116 tests pass ✅
 
 - **Repository:** https://github.com/HenriqueCSJ/q-shape
 - **Live Demo:** https://henriquecsj.github.io/q-shape
-- **DOI:** https://doi.org/10.5281/zenodo.17448252
+- **DOI:** https://doi.org/10.5281/zenodo.17717110
 - **Issues:** https://github.com/HenriqueCSJ/q-shape/issues
 - **Changelog:** https://github.com/HenriqueCSJ/q-shape/blob/main/CHANGELOG.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,7 +21,7 @@ keywords:
   - "coordination geometry"
 identifiers:
   - type: doi
-    value: "10.5281/zenodo.17448252"
+    value: "10.5281/zenodo.17717110"
     description: "Zenodo DOI for Q-Shape"
 preferred-citation:
   type: software
@@ -32,6 +32,6 @@ preferred-citation:
     - given-names: Henrique
       family-names: Castro Silva Junior
       orcid: "https://orcid.org/0000-0003-1453-7274"
-  doi: "10.5281/zenodo.17448252"
-  url: "https://doi.org/10.5281/zenodo.17448252"
+  doi: "10.5281/zenodo.17717110"
+  url: "https://doi.org/10.5281/zenodo.17717110"
   repository-code: "https://github.com/HenriqueCSJ/q-shape"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Q-Shape Logo](https://img.shields.io/badge/Q--Shape-Molecular%20Geometry%20Analysis-blue?style=for-the-badge&logo=react&logoColor=white)
 
 [![Version](https://img.shields.io/badge/version-1.4.0-blue.svg?style=flat-square)](https://github.com/HenriqueCSJ/q-shape/releases/tag/v1.4.0)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17448252.svg)](https://doi.org/10.5281/zenodo.17448252)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17717110.svg)](https://doi.org/10.5281/zenodo.17717110)
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](https://choosealicense.com/licenses/mit/)
 [![React Version](https://img.shields.io/badge/React-18.2.0-61DAFB?style=flat-square&logo=react)](https://reactjs.org/)
 [![Three.js](https://img.shields.io/badge/Three.js-r147-black?style=flat-square&logo=three.js)](https://threejs.org/)
@@ -1600,7 +1600,7 @@ If you use Q-Shape in your research, please cite:
 **APA:**
 ```
 Castro Silva Junior, H. (2025). Q-Shape - Quantitative Shape Analyzer (v1.4.0).
-Zenodo. https://doi.org/10.5281/zenodo.17448252
+Zenodo. https://doi.org/10.5281/zenodo.17717110
 ```
 
 **BibTeX:**
@@ -1610,8 +1610,8 @@ Zenodo. https://doi.org/10.5281/zenodo.17448252
   title = {Q-Shape - Quantitative Shape Analyzer},
   version = {1.4.0},
   year = {2025},
-  doi = {10.5281/zenodo.17448252},
-  url = {https://doi.org/10.5281/zenodo.17448252},
+  doi = {10.5281/zenodo.17717110},
+  url = {https://doi.org/10.5281/zenodo.17717110},
   publisher = {Zenodo}
 }
 ```

--- a/src/App.js
+++ b/src/App.js
@@ -288,7 +288,7 @@ export default function CoordinationGeometryAnalyzer() {
             Version 1.4.0 | Built: November 25, 2025
         </p>
         <p style={{fontStyle: 'italic', marginTop: '1rem', fontSize: '0.9rem'}}>
-            Cite this: Castro Silva Junior, H. (2025). Q-Shape - Quantitative Shape Analyzer (v1.4.0). Zenodo. <a href="https://doi.org/10.5281/zenodo.17448252" target="_blank" rel="noopener noreferrer" style={{color: '#4f46e5'}}>https://doi.org/10.5281/zenodo.17448252</a>
+            Cite this: Castro Silva Junior, H. (2025). Q-Shape - Quantitative Shape Analyzer (v1.4.0). Zenodo. <a href="https://doi.org/10.5281/zenodo.17717110" target="_blank" rel="noopener noreferrer" style={{color: '#4f46e5'}}>https://doi.org/10.5281/zenodo.17717110</a>
         </p>
       </header>
 

--- a/src/services/reportGenerator.js
+++ b/src/services/reportGenerator.js
@@ -415,7 +415,7 @@ footer strong {
   <p><strong>Analysis Mode:</strong> ${analysisMode === 'intensive' ? 'Intensive (High Precision) with Kabsch Alignment' : 'Standard with Improved Kabsch Alignment'}</p>
   <p style="font-style: italic; margin-top: 1rem; font-size: 0.9rem;">
     Cite this: Castro Silva Junior, H. (2025). Q-Shape - Quantitative Shape Analyzer (v1.4.0). Zenodo.
-    <a href="https://doi.org/10.5281/zenodo.17448252" style="color: #4f46e5;">https://doi.org/10.5281/zenodo.17448252</a>
+    <a href="https://doi.org/10.5281/zenodo.17717110" style="color: #4f46e5;">https://doi.org/10.5281/zenodo.17717110</a>
   </p>
 </header>
 
@@ -632,7 +632,7 @@ footer strong {
   <p style="margin-top: 1rem;">Comprehensive analysis with ${totalAvailableGeometries} reference geometries • Optimized Kabsch alignment with Jacobi SVD • Enhanced Hungarian algorithm</p>
   <p style="margin-top: 1rem; font-size: 0.85em;">
     Castro Silva Junior, H. (2025). Q-Shape - Quantitative Shape Analyzer (v1.4.0). Zenodo.
-    <a href="https://doi.org/10.5281/zenodo.17448252" style="color: #4f46e5;">https://doi.org/10.5281/zenodo.17448252</a>
+    <a href="https://doi.org/10.5281/zenodo.17717110" style="color: #4f46e5;">https://doi.org/10.5281/zenodo.17717110</a>
   </p>
   <p style="margin-top: 0.5rem; font-size: 0.85em; color: #64748b;">
     Based on Continuous Shape Measures methodology: Pinsky & Avnir (1998), Alvarez et al. (2002)


### PR DESCRIPTION
Updated DOI across all documentation and source code:
- README.md: Badge and citation
- CITATION.cff: Identifiers and preferred citation
- CHANGELOG.md: Links section
- src/App.js: UI citation display
- src/services/reportGenerator.js: PDF report citations

New DOI: 10.5281/zenodo.17717110 (v1.4.0 release)