### PR TITLE
fix: Fix macrocycle pattern detector monodentate bug (same issue)

### DIFF
--- a/src/services/coordination/patterns/patternDetector.js
+++ b/src/services/coordination/patterns/patternDetector.js
@@ -228,11 +228,12 @@ export function detectMacrocyclePattern(atoms, metalIndex, ligandGroups) {
     }
 
     // Get axial ligands (monodentate perpendicular to plane)
-    const axialLigands = monodentate.filter(idx => {
+    const axialLigands = monodentate.filter(group => {
+        const atom = group.atoms[0]; // Each monodentate group has one atom
         const coord = [
-            atoms[idx].x - atoms[metalIndex].x,
-            atoms[idx].y - atoms[metalIndex].y,
-            atoms[idx].z - atoms[metalIndex].z
+            atom.x - atoms[metalIndex].x,
+            atom.y - atoms[metalIndex].y,
+            atom.z - atoms[metalIndex].z
         ];
 
         const normal = calculateRingNormal(ringCoords);


### PR DESCRIPTION
Same bug in macrocyclePattern detector - treating monodentate as array of indices instead of array of ligand group objects.

Error: Cannot read properties of undefined (reading 'x')
    at patternDetector.js:233

This was the second occurrence of the same conceptual error. All pattern detectors now correctly handle monodentate as group objects.