### PR TITLE
fix: Prevent benzene+ligands from being misclassified as macrocycle

### DIFF
--- a/src/services/coordination/patterns/patternDetector.js
+++ b/src/services/coordination/patterns/patternDetector.js
@@ -200,6 +200,9 @@ export function detectPianoStoolPattern(atoms, metalIndex, ligandGroups) {
  * - Single large ring (typically 4+ donors in plane)
  * - Coplanar coordination
  * - Optional axial ligands
+ *
+ * NOTE: Small aromatic rings (η5-Cp, η6-benzene) with multiple monodentate
+ * ligands are piano stool complexes, NOT macrocycles!
  */
 export function detectMacrocyclePattern(atoms, metalIndex, ligandGroups) {
     const { rings, monodentate } = ligandGroups;
@@ -212,6 +215,13 @@ export function detectMacrocyclePattern(atoms, metalIndex, ligandGroups) {
 
     // Macrocycle typically has 4+ donors (porphyrin = 4N)
     if (ring.size < PATTERN_DETECTION.MIN_MACROCYCLE_SIZE) {
+        return { confidence: 0, patternType: 'macrocycle', metadata: null };
+    }
+
+    // If ring is small (≤7 atoms, like Cp or benzene) AND has multiple monodentate ligands,
+    // this is a piano stool complex, NOT a macrocycle!
+    // Macrocycles are large chelating ligands (porphyrins, corrins, crown ethers)
+    if (ring.size <= 7 && monodentate.length > 0) {
         return { confidence: 0, patternType: 'macrocycle', metadata: null };
     }
 


### PR DESCRIPTION
CRITICAL: Benzene (η6) + 3 ligands was being detected as macrocycle (90% confidence) instead of piano_stool (85% confidence), causing wrong geometry selection.

Issue: Small aromatic rings (Cp, benzene) are NOT macrocycles!
- Macrocycles: Large chelating ligands (porphyrins, corrins, crown ethers)
- Piano stool: Small ring + monodentate ligands

Fix: Reject macrocycle pattern if:
- Ring size ≤ 7 atoms (Cp/benzene range) AND
- Has monodentate ligands (piano stool indicator)

This ensures [(η6-arene)Ru(O,N,N)] is correctly identified as piano_stool, not macrocycle, and gets proper vTBPY-4 geometry instead of OC-6.