### PR TITLE
fix(critical): Use centroid-based CN for geometry matching in piano s…

### DIFF
--- a/src/services/coordination/patterns/patternDetector.js
+++ b/src/services/coordination/patterns/patternDetector.js
@@ -161,8 +161,11 @@ export function detectPianoStoolPattern(atoms, metalIndex, ligandGroups) {
 
     const ring = rings[0];
 
-    // Typical piano stool: η5-Cp (5) + 3 CO or η6-benzene (6) + 3 ligands
-    const totalCN = ring.size + monodentate.length;
+    // For geometry matching, we use centroid-based CN (1 ring centroid + N ligands)
+    // NOT the chemical CN (ring.size + monodentate.length)
+    // Example: benzene (6 atoms) + 3 ligands = CN=4 for geometry (1 centroid + 3)
+    const geometryCN = 1 + monodentate.length;
+    const chemicalCN = ring.size + monodentate.length;
 
     // Get ring coordinates
     const ringCoords = ring.indices.map(idx => [
@@ -187,7 +190,8 @@ export function detectPianoStoolPattern(atoms, metalIndex, ligandGroups) {
         metadata: {
             ringSize: ring.size,
             monodentateCount: monodentate.length,
-            coordinationNumber: totalCN,
+            coordinationNumber: geometryCN,  // Use centroid-based CN for geometry matching
+            chemicalCN: chemicalCN,  // Store actual chemical CN for reference
             ring,
             ringCoords,
             monoCoords


### PR DESCRIPTION
…tool

CRITICAL BUG: Piano stool detector was using chemical CN (ring.size + ligands) instead of geometry CN (1 centroid + ligands) for geometry selection.

Example: [(η6-benzene)Ru(O,N,N)]
- Chemical CN = 6 + 3 = 9 (wrong for geometry matching)
- Geometry CN = 1 + 3 = 4 (correct for vTBPY-4, SS-4, T-4)

Issue:
- Pattern said CN=9
- Looked for piano stool geometries for CN=9 (don't exist!)
- Fell back to general CN=9 geometries (wrong!)
- Result: Infinity CShM

Fix:
- Use geometryCN = 1 + monodentate.length for geometry matching
- Store chemicalCN separately for reference
- Now correctly selects CN=4 piano stool geometries

This was THE critical bug preventing proper piano stool analysis.