### PR TITLE
refactor: Remove pattern detection, make analysis purely ab initio

### DIFF
--- a/src/services/coordination/patterns/geometryBuilder.js
+++ b/src/services/coordination/patterns/geometryBuilder.js
@@ -256,7 +256,7 @@ export function buildMacrocycleGeometry(actualCoords, pattern, mode = 'intensive
  * Used when no specific pattern is detected
  * Evaluates all reference geometries for the CN
  */
-export function buildGeneralGeometry(actualCoords, coordinationNumber, mode = 'intensive') {
+export function buildGeneralGeometry(actualCoords, coordinationNumber, mode = 'intensive', onProgress = null) {
     console.log(`Building general geometry for CN=${coordinationNumber}`);
 
     const geometries = REFERENCE_GEOMETRIES[coordinationNumber];
@@ -268,7 +268,8 @@ export function buildGeneralGeometry(actualCoords, coordinationNumber, mode = 'i
     console.log(`Evaluating ${geometryNames.length} geometries`);
 
     const results = [];
-    for (const name of geometryNames) {
+    for (let i = 0; i < geometryNames.length; i++) {
+        const name = geometryNames[i];
         const refCoords = geometries[name];
 
         const { measure, alignedCoords, rotationMatrix } = calculateShapeMeasure(
@@ -286,6 +287,12 @@ export function buildGeneralGeometry(actualCoords, coordinationNumber, mode = 'i
             rotationMatrix,
             pattern: 'general'
         });
+
+        // Report progress
+        if (onProgress) {
+            const progress = (i + 1) / geometryNames.length;
+            onProgress(progress);
+        }
     }
 
     results.sort((a, b) => a.shapeMeasure - b.shapeMeasure);


### PR DESCRIPTION
Changes:
- Remove pattern detection and geometry filtering from intensive analysis
- Always evaluate ALL reference geometries for the CN (no special cases)
- Detect ligand groups for informational purposes only
- Add progress reporting from CShM calculations to fix stuck progress bar
- Update documentation to reflect ab initio approach

This makes the analysis truly ab initio - no chemical knowledge, no pattern matching, no geometry pre-filtering. All coordinating atoms are treated equally and all geometries are evaluated.

Progress bar now updates smoothly from 30% to 90% during CShM calculations instead of staying stuck at 40%.