### PR TITLE
feat: Add flexible geometry matching with anisotropic scaling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,12 +23,13 @@ import ResultsDisplay from './components/ResultsDisplay';
 export default function CoordinationGeometryAnalyzer() {
     // UI State (managed locally)
     const [selectedMetal, setSelectedMetal] = useState(null);
-    const [analysisParams, setAnalysisParams] = useState({ mode: 'default', key: 0 });
+    const [analysisParams, setAnalysisParams] = useState({ mode: 'default', key: 0, flexible: false });
     const [autoRotate, setAutoRotate] = useState(false);
     const [showIdeal, setShowIdeal] = useState(true);
     const [showLabels, setShowLabels] = useState(true);
     const [warnings, setWarnings] = useState([]);
     const [selectedGeometryIndex, setSelectedGeometryIndex] = useState(0); // Index of geometry to visualize
+    const [flexibleMode, setFlexibleMode] = useState(false); // Flexible geometry matching mode
 
     // Intensive Analysis State
     const [intensiveMetadata, setIntensiveMetadata] = useState(null);
@@ -54,6 +55,15 @@ export default function CoordinationGeometryAnalyzer() {
 
     const handleError = useCallback((msg) => {
         setWarnings(prev => [...prev, `Error: ${msg}`]);
+    }, []);
+
+    const handleFlexibleModeChange = useCallback((enabled) => {
+        setFlexibleMode(enabled);
+        setAnalysisParams(prev => ({
+            ...prev,
+            flexible: enabled,
+            key: Date.now() // Trigger re-analysis
+        }));
     }, []);
 
     // Radius Control Hook (v1.1.0) - defined before use
@@ -361,6 +371,8 @@ export default function CoordinationGeometryAnalyzer() {
           onCoordRadiusChange={setCoordRadius}
           onAutoRadiusChange={setAutoRadius}
           onTargetCNInputChange={setTargetCNInput}
+          flexibleMode={flexibleMode}
+          onFlexibleModeChange={handleFlexibleModeChange}
         />
 
         <CoordinationSummary

--- a/src/components/AnalysisControls.jsx
+++ b/src/components/AnalysisControls.jsx
@@ -23,7 +23,9 @@ export default function AnalysisControls({
     onDecrementRadius,
     onCoordRadiusChange,
     onAutoRadiusChange,
-    onTargetCNInputChange
+    onTargetCNInputChange,
+    flexibleMode,
+    onFlexibleModeChange
 }) {
     return (
         <div className="controls-section">
@@ -44,6 +46,51 @@ export default function AnalysisControls({
                         </option>
                     ))}
                 </select>
+            </div>
+
+            {/* Flexible Geometry Matching Toggle */}
+            <div className="card">
+                <label className="control-label">
+                    🔧 Geometry Matching Mode
+                </label>
+                <label className="checkbox-label" style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    padding: '0.75rem',
+                    background: flexibleMode ? '#f0f9ff' : '#f9fafb',
+                    border: flexibleMode ? '2px solid #3b82f6' : '2px solid #e2e8f0',
+                    borderRadius: '8px',
+                    cursor: 'pointer',
+                    transition: 'all 0.2s'
+                }}>
+                    <input
+                        type="checkbox"
+                        checked={flexibleMode}
+                        onChange={(e) => onFlexibleModeChange && onFlexibleModeChange(e.target.checked)}
+                        style={{ cursor: 'pointer' }}
+                    />
+                    <div style={{ flex: 1 }}>
+                        <div style={{ fontWeight: 600, color: flexibleMode ? '#1e40af' : '#475569' }}>
+                            {flexibleMode ? '✨ Flexible (Anisotropic Scaling)' : '📐 Rigid (Standard)'}
+                        </div>
+                        <div style={{ fontSize: '0.75rem', color: '#64748b', marginTop: '0.25rem' }}>
+                            {flexibleMode
+                                ? 'Allows reference geometries to scale along principal axes'
+                                : 'Uses fixed reference geometries (traditional CShM)'}
+                        </div>
+                    </div>
+                </label>
+                <div style={{
+                    fontSize: '0.8rem',
+                    color: '#64748b',
+                    marginTop: '0.5rem',
+                    padding: '0.5rem',
+                    background: '#f8fafc',
+                    borderRadius: '6px'
+                }}>
+                    <strong>Flexible mode</strong> helps identify distorted geometries (e.g., piano stools, compressed/elongated structures) by reporting both rigid and flexible CShM values.
+                </div>
             </div>
 
             {/* Coordination Radius Control */}

--- a/src/components/ResultsDisplay.jsx
+++ b/src/components/ResultsDisplay.jsx
@@ -132,13 +132,47 @@ export default function ResultsDisplay({
                                             {POINT_GROUPS[r.name] || ''}
                                         </span>
                                     </div>
-                                    <div style={{
-                                        fontSize: '1.1rem',
-                                        fontWeight: 800,
-                                        color: inter.color,
-                                        fontFamily: 'monospace'
-                                    }}>
-                                        {r.shapeMeasure.toFixed(4)}
+                                    <div style={{ textAlign: 'right' }}>
+                                        {r.rigidMeasure != null ? (
+                                            // Flexible mode: show both values
+                                            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                                                <div style={{
+                                                    fontSize: '0.75rem',
+                                                    color: '#64748b',
+                                                    fontFamily: 'monospace'
+                                                }}>
+                                                    Rigid: {r.rigidMeasure.toFixed(3)}
+                                                </div>
+                                                <div style={{
+                                                    fontSize: '1.05rem',
+                                                    fontWeight: 800,
+                                                    color: inter.color,
+                                                    fontFamily: 'monospace'
+                                                }}>
+                                                    Flex: {r.flexibleMeasure.toFixed(3)}
+                                                </div>
+                                                {r.delta > 0.1 && (
+                                                    <div style={{
+                                                        fontSize: '0.7rem',
+                                                        color: '#10b981',
+                                                        fontFamily: 'monospace',
+                                                        fontWeight: 600
+                                                    }}>
+                                                        Δ = -{r.delta.toFixed(2)}
+                                                    </div>
+                                                )}
+                                            </div>
+                                        ) : (
+                                            // Rigid-only mode: show single value
+                                            <div style={{
+                                                fontSize: '1.1rem',
+                                                fontWeight: 800,
+                                                color: inter.color,
+                                                fontFamily: 'monospace'
+                                            }}>
+                                                {r.shapeMeasure.toFixed(4)}
+                                            </div>
+                                        )}
                                     </div>
                                 </div>
                                 <div style={{
@@ -157,6 +191,31 @@ export default function ResultsDisplay({
                                         {inter.confidence}%
                                     </span>
                                 </div>
+                                {r.scaling && (
+                                    <div style={{
+                                        marginTop: '0.5rem',
+                                        paddingTop: '0.5rem',
+                                        borderTop: '1px dashed #e2e8f0',
+                                        fontSize: '0.75rem',
+                                        color: '#64748b'
+                                    }}>
+                                        <div style={{ marginBottom: '0.25rem' }}>
+                                            <strong>Scaling:</strong> {r.scaling.description}
+                                        </div>
+                                        <div style={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                                            sx={r.scaling.sx.toFixed(2)}, sy={r.scaling.sy.toFixed(2)}, sz={r.scaling.sz.toFixed(2)}
+                                            {r.scaling.distortion != null && (
+                                                <span style={{
+                                                    marginLeft: '0.5rem',
+                                                    color: r.scaling.distortion < 5 ? '#10b981' : r.scaling.distortion < 15 ? '#f59e0b' : '#dc2626',
+                                                    fontWeight: 600
+                                                }}>
+                                                    • Distortion: {r.scaling.distortion.toFixed(1)}%
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         );
                     })}

--- a/src/services/shapeAnalysis/anisotropicScaling.js
+++ b/src/services/shapeAnalysis/anisotropicScaling.js
@@ -1,0 +1,344 @@
+/**
+ * Anisotropic Scaling for Reference Geometries
+ *
+ * Allows reference polyhedra to be scaled along their principal axes
+ * to better match distorted coordination geometries (e.g., piano stools,
+ * compressed/elongated structures).
+ *
+ * This provides a "flexible" shape matching mode that distinguishes:
+ * - "Wrong geometry" (high CShM even with scaling)
+ * - "Distorted geometry" (low CShM with scaling, but high scaling distortion)
+ */
+
+import * as THREE from 'three';
+import { calculatePrincipalAxes } from './propertyAnalysis.js';
+
+/**
+ * Pre-compute principal axes for a reference geometry
+ * These define the natural scaling axes for the polyhedron
+ *
+ * @param {Array<THREE.Vector3>} refVectors - Reference geometry vertices (normalized)
+ * @returns {Object} { axes: [v1, v2, v3], eigenvalues, rotation }
+ */
+export function computeReferenceAxes(refVectors) {
+    // Convert to coordinate arrays
+    const coords = refVectors.map(v => [v.x, v.y, v.z]);
+
+    // Calculate principal axes using PCA
+    const pca = calculatePrincipalAxes(coords);
+
+    if (pca.axes.length < 3) {
+        // Fallback to standard axes if PCA fails
+        return {
+            axes: [
+                new THREE.Vector3(1, 0, 0),
+                new THREE.Vector3(0, 1, 0),
+                new THREE.Vector3(0, 0, 1)
+            ],
+            eigenvalues: [1, 1, 1],
+            rotation: new THREE.Matrix4()
+        };
+    }
+
+    // Build rotation matrix from principal axes
+    // This transforms from PCA space to world space
+    const rotation = new THREE.Matrix4();
+    rotation.makeBasis(pca.axes[0], pca.axes[1], pca.axes[2]);
+
+    return {
+        axes: pca.axes,
+        eigenvalues: pca.eigenvalues,
+        rotation
+    };
+}
+
+/**
+ * Apply anisotropic scaling to reference geometry
+ *
+ * @param {Array<THREE.Vector3>} refVectors - Reference geometry vertices
+ * @param {Object} refAxes - Pre-computed reference axes from computeReferenceAxes
+ * @param {number} sx - Scale factor along principal axis 1
+ * @param {number} sy - Scale factor along principal axis 2
+ * @param {number} sz - Scale factor along principal axis 3
+ * @returns {Array<THREE.Vector3>} Scaled reference vectors
+ */
+export function applyAnisotropicScaling(refVectors, refAxes, sx, sy, sz) {
+    const { rotation } = refAxes;
+    const inverseRotation = rotation.clone().invert();
+
+    // Build scaling matrix in PCA space
+    const scalingMatrix = new THREE.Matrix4().makeScale(sx, sy, sz);
+
+    // Transform to PCA space, scale, transform back
+    // T = R * S * R^(-1)
+    const transform = new THREE.Matrix4()
+        .multiply(rotation)
+        .multiply(scalingMatrix)
+        .multiply(inverseRotation);
+
+    return refVectors.map(v => v.clone().applyMatrix4(transform));
+}
+
+/**
+ * Calculate distortion index from scaling parameters
+ * Measures how much the reference geometry had to be distorted
+ *
+ * Higher values = more distortion needed
+ * 0 = no distortion (isotropic scaling or sx=sy=sz=1)
+ *
+ * @param {number} sx - Scale factor along axis 1
+ * @param {number} sy - Scale factor along axis 2
+ * @param {number} sz - Scale factor along axis 3
+ * @returns {number} Distortion index (0-100 scale)
+ */
+export function calculateDistortionIndex(sx, sy, sz) {
+    // Geometric mean (average scale)
+    const meanScale = Math.pow(sx * sy * sz, 1/3);
+
+    // Normalize scales relative to mean
+    const s1 = sx / meanScale;
+    const s2 = sy / meanScale;
+    const s3 = sz / meanScale;
+
+    // Calculate variance from unity
+    const variance = ((s1-1)**2 + (s2-1)**2 + (s3-1)**2) / 3;
+
+    // Convert to 0-100 scale (empirically calibrated)
+    // variance of ~0.01 = distortion ~3
+    // variance of ~0.05 = distortion ~10
+    // variance of ~0.20 = distortion ~30
+    const distortion = Math.sqrt(variance) * 100;
+
+    return distortion;
+}
+
+/**
+ * Optimize scaling parameters to minimize CShM
+ * Uses gradient descent with bounds constraints
+ *
+ * @param {Array<THREE.Vector3>} actualVecs - Actual structure vertices (normalized)
+ * @param {Array<THREE.Vector3>} refVecs - Reference geometry vertices (normalized)
+ * @param {Object} refAxes - Pre-computed reference axes
+ * @param {THREE.Matrix4} rotationMatrix - Optimal rotation (from rigid alignment)
+ * @param {Function} getMeasure - Function that calculates CShM given scaled ref vectors
+ * @param {Object} options - { minScale, maxScale, preserveVolume, initialScales }
+ * @returns {Object} { sx, sy, sz, measure, iterations }
+ */
+export function optimizeScaling(actualVecs, refVecs, refAxes, rotationMatrix, getMeasure, options = {}) {
+    const {
+        minScale = 0.5,
+        maxScale = 2.0,
+        preserveVolume = false,
+        initialScales = [1.0, 1.0, 1.0],
+        maxIterations = 500,
+        tolerance = 1e-6
+    } = options;
+
+    let [sx, sy, sz] = initialScales;
+
+    // Ensure volume preservation if requested
+    if (preserveVolume) {
+        const volume = sx * sy * sz;
+        sz = volume / (sx * sy);
+    }
+
+    // Clamp to bounds
+    const clamp = (val) => Math.max(minScale, Math.min(maxScale, val));
+    sx = clamp(sx);
+    sy = clamp(sy);
+    sz = clamp(sz);
+
+    let bestMeasure = Infinity;
+    let bestScales = [sx, sy, sz];
+
+    // Gradient descent with adaptive step size
+    let stepSize = 0.1;
+    const stepDecay = 0.95;
+    const minStepSize = 1e-4;
+
+    for (let iter = 0; iter < maxIterations; iter++) {
+        // Evaluate current position
+        const scaledRef = applyAnisotropicScaling(refVecs, refAxes, sx, sy, sz);
+        const currentMeasure = getMeasure(scaledRef);
+
+        if (currentMeasure < bestMeasure) {
+            bestMeasure = currentMeasure;
+            bestScales = [sx, sy, sz];
+        }
+
+        // Early termination if excellent match
+        if (currentMeasure < 0.01) break;
+
+        // Numerical gradient (finite differences)
+        const epsilon = 1e-4;
+        const gradSx = (getMeasure(applyAnisotropicScaling(refVecs, refAxes, sx + epsilon, sy, sz)) - currentMeasure) / epsilon;
+        const gradSy = (getMeasure(applyAnisotropicScaling(refVecs, refAxes, sx, sy + epsilon, sz)) - currentMeasure) / epsilon;
+        const gradSz = (getMeasure(applyAnisotropicScaling(refVecs, refAxes, sx, sy, sz + epsilon)) - currentMeasure) / epsilon;
+
+        // Update with gradient descent
+        let newSx = sx - stepSize * gradSx;
+        let newSy = sy - stepSize * gradSy;
+        let newSz = sz - stepSize * gradSz;
+
+        // Volume preservation constraint
+        if (preserveVolume) {
+            const currentVolume = sx * sy * sz;
+            newSz = currentVolume / (newSx * newSy);
+        }
+
+        // Clamp to bounds
+        newSx = clamp(newSx);
+        newSy = clamp(newSy);
+        newSz = clamp(newSz);
+
+        // Check convergence
+        const change = Math.abs(newSx - sx) + Math.abs(newSy - sy) + Math.abs(newSz - sz);
+        if (change < tolerance) break;
+
+        sx = newSx;
+        sy = newSy;
+        sz = newSz;
+
+        // Decay step size
+        stepSize = Math.max(minStepSize, stepSize * stepDecay);
+    }
+
+    return {
+        sx: bestScales[0],
+        sy: bestScales[1],
+        sz: bestScales[2],
+        measure: bestMeasure,
+        iterations: maxIterations
+    };
+}
+
+/**
+ * Simplified scaling optimization using simulated annealing
+ * More robust for non-convex optimization landscapes
+ *
+ * @param {Function} getMeasure - Function: (sx, sy, sz) => CShM value
+ * @param {Object} options - Configuration options
+ * @returns {Object} { sx, sy, sz, measure }
+ */
+export function optimizeScalingAnnealing(getMeasure, options = {}) {
+    const {
+        minScale = 0.5,
+        maxScale = 2.0,
+        preserveVolume = false,
+        initialTemp = 0.5,
+        coolingRate = 0.95,
+        iterations = 1000,
+        restarts = 3
+    } = options;
+
+    const clamp = (val) => Math.max(minScale, Math.min(maxScale, val));
+
+    let globalBest = { sx: 1, sy: 1, sz: 1, measure: Infinity };
+
+    for (let restart = 0; restart < restarts; restart++) {
+        // Random initialization (or start from [1,1,1] on first restart)
+        let sx = restart === 0 ? 1.0 : minScale + Math.random() * (maxScale - minScale);
+        let sy = restart === 0 ? 1.0 : minScale + Math.random() * (maxScale - minScale);
+        let sz = restart === 0 ? 1.0 : minScale + Math.random() * (maxScale - minScale);
+
+        if (preserveVolume) {
+            sz = 1.0 / (sx * sy); // Ensure volume = 1
+            sz = clamp(sz);
+        }
+
+        let currentMeasure = getMeasure(sx, sy, sz);
+        let bestMeasure = currentMeasure;
+        let bestScales = { sx, sy, sz };
+
+        let temp = initialTemp;
+
+        for (let iter = 0; iter < iterations; iter++) {
+            // Propose new scales with random perturbation
+            const perturbation = temp * 0.2;
+            let newSx = sx + (Math.random() - 0.5) * 2 * perturbation;
+            let newSy = sy + (Math.random() - 0.5) * 2 * perturbation;
+            let newSz = sz + (Math.random() - 0.5) * 2 * perturbation;
+
+            // Volume preservation
+            if (preserveVolume) {
+                newSz = (sx * sy * sz) / (newSx * newSy);
+            }
+
+            // Clamp to bounds
+            newSx = clamp(newSx);
+            newSy = clamp(newSy);
+            newSz = clamp(newSz);
+
+            const newMeasure = getMeasure(newSx, newSy, newSz);
+
+            // Metropolis criterion
+            const delta = newMeasure - currentMeasure;
+            const accept = delta < 0 || Math.random() < Math.exp(-delta / temp);
+
+            if (accept) {
+                sx = newSx;
+                sy = newSy;
+                sz = newSz;
+                currentMeasure = newMeasure;
+
+                if (currentMeasure < bestMeasure) {
+                    bestMeasure = currentMeasure;
+                    bestScales = { sx, sy, sz };
+                }
+            }
+
+            // Cool down
+            temp *= coolingRate;
+
+            // Early termination
+            if (bestMeasure < 0.01) break;
+        }
+
+        if (bestMeasure < globalBest.measure) {
+            globalBest = { ...bestScales, measure: bestMeasure };
+        }
+    }
+
+    return globalBest;
+}
+
+/**
+ * Format scaling parameters for display
+ *
+ * @param {number} sx - Scale along axis 1
+ * @param {number} sy - Scale along axis 2
+ * @param {number} sz - Scale along axis 3
+ * @returns {string} Human-readable description
+ */
+export function formatScalingDescription(sx, sy, sz) {
+    const tolerance = 0.05; // 5% tolerance for "approximately equal"
+
+    // Check if isotropic (all equal)
+    if (Math.abs(sx - sy) < tolerance && Math.abs(sy - sz) < tolerance) {
+        if (Math.abs(sx - 1.0) < tolerance) {
+            return 'No scaling';
+        }
+        const percent = ((sx - 1.0) * 100).toFixed(0);
+        return percent > 0 ? `Uniformly expanded (${percent}%)` : `Uniformly compressed (${Math.abs(percent)}%)`;
+    }
+
+    // Find most and least scaled axes
+    const scales = [
+        { axis: 'X', value: sx },
+        { axis: 'Y', value: sy },
+        { axis: 'Z', value: sz }
+    ];
+    scales.sort((a, b) => b.value - a.value);
+
+    const descriptions = [];
+    if (scales[0].value > 1.0 + tolerance) {
+        const percent = ((scales[0].value - 1.0) * 100).toFixed(0);
+        descriptions.push(`elongated along ${scales[0].axis} (+${percent}%)`);
+    }
+    if (scales[2].value < 1.0 - tolerance) {
+        const percent = ((1.0 - scales[2].value) * 100).toFixed(0);
+        descriptions.push(`compressed along ${scales[2].axis} (-${percent}%)`);
+    }
+
+    return descriptions.length > 0 ? descriptions.join(', ') : 'Anisotropic scaling';
+}

--- a/src/services/shapeAnalysis/flexibleShapeCalculator.js
+++ b/src/services/shapeAnalysis/flexibleShapeCalculator.js
@@ -1,0 +1,302 @@
+/**
+ * Flexible Shape Measure Calculator
+ *
+ * Extends the rigid CShM calculation with anisotropic scaling support.
+ * Computes both:
+ * - Rigid CShM: Traditional shape measure (no scaling)
+ * - Flexible CShM: Shape measure with optimized anisotropic scaling
+ *
+ * This allows distinguishing between:
+ * - "Wrong geometry" (high CShM even with scaling)
+ * - "Distorted correct geometry" (low flexible CShM, but with distortion)
+ */
+
+import * as THREE from 'three';
+import calculateShapeMeasure from './shapeCalculator.js';
+import hungarianAlgorithm from '../algorithms/hungarian.js';
+import {
+    computeReferenceAxes,
+    applyAnisotropicScaling,
+    optimizeScalingAnnealing,
+    calculateDistortionIndex,
+    formatScalingDescription
+} from './anisotropicScaling.js';
+import { KABSCH } from '../../constants/algorithmConstants.js';
+
+/**
+ * Calculate both rigid and flexible shape measures
+ *
+ * @param {Array<Array<number>>} actualCoords - Actual structure coordinates
+ * @param {Array<Array<number>>} referenceCoords - Reference polyhedron coordinates
+ * @param {string} mode - 'default' or 'intensive'
+ * @param {Function} progressCallback - Progress reporting function
+ * @returns {Object} {
+ *   rigid: { measure, alignedCoords, rotationMatrix },
+ *   flexible: { measure, alignedCoords, rotationMatrix, scaling: { sx, sy, sz, distortion, description } },
+ *   delta: number,
+ *   improvement: number (percentage)
+ * }
+ */
+export function calculateFlexibleShapeMeasure(actualCoords, referenceCoords, mode = 'default', progressCallback = null) {
+    const N = actualCoords.length;
+    if (N !== referenceCoords.length || N === 0) {
+        return {
+            rigid: { measure: Infinity, alignedCoords: [], rotationMatrix: new THREE.Matrix4() },
+            flexible: { measure: Infinity, alignedCoords: [], rotationMatrix: new THREE.Matrix4(), scaling: null },
+            delta: 0,
+            improvement: 0
+        };
+    }
+
+    // Stage 1: Calculate rigid CShM (standard algorithm)
+    if (progressCallback) {
+        progressCallback({
+            stage: 'rigid_alignment',
+            percentage: 0,
+            current: 0,
+            total: 100,
+            extra: 'Calculating rigid shape measure...'
+        });
+    }
+
+    const rigidResult = calculateShapeMeasure(actualCoords, referenceCoords, mode, (progress) => {
+        if (progressCallback) {
+            // Map rigid calculation to 0-50% of overall progress
+            progressCallback({
+                ...progress,
+                percentage: progress.percentage * 0.5,
+                stage: `rigid_${progress.stage}`
+            });
+        }
+    });
+
+    if (rigidResult.measure === Infinity) {
+        return {
+            rigid: rigidResult,
+            flexible: { ...rigidResult, scaling: null },
+            delta: 0,
+            improvement: 0
+        };
+    }
+
+    // Stage 2: Calculate flexible CShM (with anisotropic scaling)
+    if (progressCallback) {
+        progressCallback({
+            stage: 'flexible_optimization',
+            percentage: 50,
+            current: 0,
+            total: 100,
+            extra: 'Optimizing anisotropic scaling...'
+        });
+    }
+
+    try {
+        const flexibleResult = calculateFlexibleCShM(
+            actualCoords,
+            referenceCoords,
+            rigidResult.rotationMatrix,
+            mode,
+            (progress) => {
+                if (progressCallback) {
+                    // Map flexible calculation to 50-100% of overall progress
+                    progressCallback({
+                        stage: 'flexible_scaling',
+                        percentage: 50 + progress * 0.5,
+                        current: progress,
+                        total: 100,
+                        extra: 'Optimizing scaling parameters...'
+                    });
+                }
+            }
+        );
+
+        // Calculate delta and improvement
+        const delta = rigidResult.measure - flexibleResult.measure;
+        const improvement = rigidResult.measure > 0
+            ? (delta / rigidResult.measure) * 100
+            : 0;
+
+        if (progressCallback) {
+            progressCallback({
+                stage: 'complete',
+                percentage: 100,
+                current: 100,
+                total: 100,
+                extra: `Δ = ${delta.toFixed(2)}, improvement = ${improvement.toFixed(1)}%`
+            });
+        }
+
+        return {
+            rigid: rigidResult,
+            flexible: flexibleResult,
+            delta,
+            improvement
+        };
+
+    } catch (error) {
+        console.error('Error in flexible shape calculation:', error);
+        // Fallback to rigid-only results
+        return {
+            rigid: rigidResult,
+            flexible: { ...rigidResult, scaling: null },
+            delta: 0,
+            improvement: 0
+        };
+    }
+}
+
+/**
+ * Calculate flexible CShM with anisotropic scaling optimization
+ * Internal function - uses rigid alignment as starting point
+ */
+function calculateFlexibleCShM(actualCoords, referenceCoords, rigidRotation, mode, progressCallback) {
+    const N = actualCoords.length;
+
+    // Normalize coordinates
+    const P_vecs = actualCoords.map(c => new THREE.Vector3(...c));
+    if (P_vecs.some(v => v.lengthSq() < KABSCH.MIN_VECTOR_LENGTH_SQ)) {
+        throw new Error("Invalid coordinates");
+    }
+    P_vecs.forEach(v => v.normalize());
+
+    const Q_vecs = referenceCoords.map(c => new THREE.Vector3(...c));
+
+    // Pre-compute reference geometry principal axes
+    const refAxes = computeReferenceAxes(Q_vecs);
+
+    // Define measure function for scaling optimization
+    const getMeasureForScaling = (sx, sy, sz) => {
+        // Apply anisotropic scaling to reference
+        const scaledQ = applyAnisotropicScaling(Q_vecs, refAxes, sx, sy, sz);
+
+        // Apply rigid rotation to actual coordinates
+        const rotatedP = P_vecs.map(p => p.clone().applyMatrix4(rigidRotation));
+
+        // Compute cost matrix
+        const costMatrix = [];
+        for (let i = 0; i < N; i++) {
+            costMatrix[i] = [];
+            for (let j = 0; j < N; j++) {
+                costMatrix[i][j] = rotatedP[i].distanceToSquared(scaledQ[j]);
+            }
+        }
+
+        // Optimal assignment
+        const matching = hungarianAlgorithm(costMatrix);
+        const sumSqDiff = matching.reduce((sum, [i, j]) => sum + costMatrix[i][j], 0);
+
+        return (sumSqDiff / N) * 100;
+    };
+
+    // Optimize scaling parameters using simulated annealing
+    const scalingOptions = {
+        minScale: 0.4,
+        maxScale: 2.5,
+        preserveVolume: false, // Allow volume changes for now
+        initialTemp: mode === 'intensive' ? 0.8 : 0.5,
+        coolingRate: mode === 'intensive' ? 0.96 : 0.94,
+        iterations: mode === 'intensive' ? 2000 : 1000,
+        restarts: mode === 'intensive' ? 5 : 3
+    };
+
+    const optimalScaling = optimizeScalingAnnealing(getMeasureForScaling, scalingOptions);
+
+    // Apply optimal scaling to get final result
+    const scaledQ = applyAnisotropicScaling(Q_vecs, refAxes, optimalScaling.sx, optimalScaling.sy, optimalScaling.sz);
+    const rotatedP = P_vecs.map(p => p.clone().applyMatrix4(rigidRotation));
+
+    // Final cost matrix and matching
+    const costMatrix = [];
+    for (let i = 0; i < N; i++) {
+        costMatrix[i] = [];
+        for (let j = 0; j < N; j++) {
+            costMatrix[i][j] = rotatedP[i].distanceToSquared(scaledQ[j]);
+        }
+    }
+
+    const finalMatching = hungarianAlgorithm(costMatrix);
+
+    // Build aligned coordinates
+    const alignedCoords = new Array(N);
+    for (const [i, j] of finalMatching) {
+        const rotated = rotatedP[i];
+        alignedCoords[j] = [rotated.x, rotated.y, rotated.z];
+    }
+
+    // Calculate distortion metrics
+    const distortion = calculateDistortionIndex(optimalScaling.sx, optimalScaling.sy, optimalScaling.sz);
+    const description = formatScalingDescription(optimalScaling.sx, optimalScaling.sy, optimalScaling.sz);
+
+    return {
+        measure: optimalScaling.measure,
+        alignedCoords: alignedCoords.filter(Boolean),
+        rotationMatrix: rigidRotation.clone(),
+        scaling: {
+            sx: optimalScaling.sx,
+            sy: optimalScaling.sy,
+            sz: optimalScaling.sz,
+            distortion,
+            description
+        }
+    };
+}
+
+/**
+ * Interpret flexible vs rigid results
+ * Provides scientific interpretation of the difference
+ *
+ * @param {number} rigidCShM - Rigid shape measure
+ * @param {number} flexibleCShM - Flexible shape measure
+ * @param {number} distortion - Distortion index
+ * @returns {Object} { category, interpretation, recommendation }
+ */
+export function interpretFlexibleResults(rigidCShM, flexibleCShM, distortion) {
+    const delta = rigidCShM - flexibleCShM;
+    const improvement = rigidCShM > 0 ? (delta / rigidCShM) * 100 : 0;
+
+    // Classification logic
+    if (flexibleCShM > 10.0) {
+        return {
+            category: 'wrong_geometry',
+            interpretation: 'This geometry is not a good match, even with distortion.',
+            recommendation: 'Try a different reference geometry.',
+            color: '#dc2626' // red
+        };
+    }
+
+    if (delta < 1.0 || improvement < 10) {
+        return {
+            category: 'rigid_match',
+            interpretation: 'The structure matches well without needing distortion.',
+            recommendation: 'Use the rigid CShM value.',
+            color: '#16a34a' // green
+        };
+    }
+
+    if (distortion < 5.0) {
+        return {
+            category: 'slight_distortion',
+            interpretation: 'The structure is slightly distorted from the ideal geometry.',
+            recommendation: 'This is a good match with minor distortion.',
+            color: '#16a34a' // green
+        };
+    }
+
+    if (distortion < 15.0) {
+        return {
+            category: 'moderate_distortion',
+            interpretation: 'The structure shows moderate distortion from the ideal geometry.',
+            recommendation: 'Consider reporting both rigid and flexible CShM values.',
+            color: '#ea580c' // orange
+        };
+    }
+
+    return {
+        category: 'high_distortion',
+        interpretation: 'The structure is heavily distorted from the ideal geometry.',
+        recommendation: 'This may indicate a different geometry type or significant structural strain.',
+        color: '#dc2626' // red
+    };
+}
+
+export default calculateFlexibleShapeMeasure;


### PR DESCRIPTION
Implements anisotropic scaling for reference geometries to better match distorted coordination structures (e.g., piano stools, compressed/elongated geometries).

Key features:
- New anisotropicScaling.js module with PCA-based principal axis detection
- Flexible shape calculator that optimizes scaling along 3 principal axes
- Dual CShM reporting: rigid (traditional) and flexible (with scaling)
- Delta value showing improvement from scaling
- Distortion index quantifying how much scaling was needed
- UI toggle for Rigid vs. Flexible matching modes
- Enhanced results display showing both CShM values side-by-side
- Scaling parameters (sx, sy, sz) and description in results

This scientifically sound approach:
- Preserves angular relationships (only scales distances)
- Distinguishes "wrong geometry" from "distorted correct geometry"
- Provides transparent reporting with both rigid and flexible CShM
- Uses simulated annealing for robust optimization
- Supports volume-preserving constraints (optional)

Addresses issue with piano stool geometries where traditional rigid CShM fails to recognize the correct geometry type due to height variations.