### PR TITLE
fix: Cache keys include flexible flag and compact UI text

### DIFF
--- a/src/components/AnalysisControls.jsx
+++ b/src/components/AnalysisControls.jsx
@@ -85,18 +85,18 @@ export default function AnalysisControls({
                                 fontSize: '0.95rem',
                                 marginBottom: '0.25rem'
                             }}>
-                                {flexibleMode ? '✨ Flexible (Anisotropic Scaling)' : '📐 Rigid (Standard)'}
+                                {flexibleMode ? '✨ Flexible (Anisotropic)' : '📐 Rigid (Standard)'}
                             </div>
                             <div style={{ fontSize: '0.8rem', color: '#64748b', lineHeight: '1.4' }}>
                                 {flexibleMode
-                                    ? 'Allows reference geometries to scale along principal axes'
-                                    : 'Uses fixed reference geometries (traditional CShM)'}
+                                    ? 'Scales reference along principal axes'
+                                    : 'Fixed reference geometries'}
                             </div>
                         </div>
                     </label>
                 </div>
                 <div style={{
-                    fontSize: '0.8rem',
+                    fontSize: '0.75rem',
                     color: '#64748b',
                     marginTop: '0.5rem',
                     padding: '0.5rem',
@@ -104,7 +104,7 @@ export default function AnalysisControls({
                     borderRadius: '6px',
                     lineHeight: '1.4'
                 }}>
-                    💡 <strong>Flexible mode</strong> helps identify distorted geometries (piano stools, compressed structures) by showing both rigid and flexible CShM values with delta.
+                    💡 Shows both rigid and flexible CShM with Δ for distorted geometries
                 </div>
             </div>
 

--- a/src/hooks/useShapeAnalysis.js
+++ b/src/hooks/useShapeAnalysis.js
@@ -54,13 +54,14 @@ export function useShapeAnalysis({
     const resultsCache = useRef(new Map());
 
     // Generate cache key
-    const getCacheKey = useCallback((atoms, mode) => {
+    const getCacheKey = useCallback((atoms, mode, flexible = false) => {
         if (!atoms || atoms.length === 0) return null;
         try {
             const coordKey = atoms.map(c =>
                 `${c.atom.element}${c.distance.toFixed(3)}`
             ).join('-');
-            return `${mode}-cn${atoms.length}-${coordKey}`;
+            const flexFlag = flexible ? '-flex' : '-rigid';
+            return `${mode}-cn${atoms.length}${flexFlag}-${coordKey}`;
         } catch (error) {
             console.error("Error generating cache key:", error);
             return null;
@@ -108,7 +109,7 @@ export function useShapeAnalysis({
         }
 
         const cn = coordAtoms.length;
-        const cacheKey = getCacheKey(coordAtoms, analysisParams.mode);
+        const cacheKey = getCacheKey(coordAtoms, analysisParams.mode, analysisParams.flexible);
 
         // Check cache
         if (cacheKey && resultsCache.current.has(cacheKey)) {
@@ -219,7 +220,7 @@ export function useShapeAnalysis({
 
                             if (useFlexible) {
                                 // Check if we have cached rigid results to reuse
-                                const rigidCacheKey = getCacheKey(coordAtoms, analysisParams.mode);
+                                const rigidCacheKey = getCacheKey(coordAtoms, analysisParams.mode, false); // false = rigid cache
                                 const cachedRigid = rigidCacheKey ? resultsCache.current.get(rigidCacheKey) : null;
                                 const existingRigidResult = cachedRigid?.results?.find(r => r.name === name);
 


### PR DESCRIPTION
Critical fix:
- Cache keys now include flexible flag (-rigid or -flex suffix)
- This ensures flexible mode recalculates instead of returning cached rigid results
- When toggling to flexible, looks up rigid cache (without flex flag) to reuse

UI improvements:
- Shortened text: 'Flexible (Anisotropic)' instead of full name
- Compact descriptions: 'Scales reference along principal axes'
- Smaller help text to prevent wrapping on narrow screens
- Better layout for 280px minimum card width

This fixes the issue where toggling flexible mode had no effect.